### PR TITLE
Added A7A7, Added Improvements to Libretro Build

### DIFF
--- a/builds/libretro/Makefile.libretro
+++ b/builds/libretro/Makefile.libretro
@@ -1,4 +1,9 @@
 RETRO_CROSSCOMPILING=0
+RETRO_DEPFLAGS=0
+
+ifeq ($(COMPILER_CORE_COUNT),)
+	COMPILER_CORE_COUNT=4
+endif
 
 ifeq ($(platform),)
 	platform = unix
@@ -123,6 +128,12 @@ else ifeq ($(platform), classic_armv7_a7)
 	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
 	-fmerge-all-constants -fno-math-errno \
 	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	RETRO_DEPFLAGS += -Ofast \
+	-fno-stack-protector -fno-ident -fomit-frame-pointer \
+	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
+	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
+	-fmerge-all-constants -fno-math-errno \
+	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
 	LDFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
 	HAVE_NEON = 1
 	ARCH = arm
@@ -193,25 +204,32 @@ ifeq ($(RETRO_PROFILE),1)
 endif
 
 OBJECTS		= $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o)
-CXXFLAGS       += -D__LIBRETRO__ -fpermissive $(fpic) $(INCDIR) $(COMMON_DEFINES)
-CFLAGS	       += -D__LIBRETRO__ $(fpic) $(INCDIR) $(COMMON_DEFINES)
+
+# RETRO_DEPFLAGS are used for compiler flags specificly for dependencies and seperated
+# away from the Libretro target compiler flags.
+ifneq ($(RETRO_DEPFLAGS), 0)
+	DEPCXXFLAGS    += -D__LIBRETRO__ -fpermissive $(fpic) $(INCDIR) $(RETRO_DEPFLAGS)
+	DEPCFLAGS	   += -D__LIBRETRO__ $(fpic) $(INCDIR) $(RETRO_DEPFLAGS)
+	CXXFLAGS       += -D__LIBRETRO__ -fpermissive $(fpic) $(INCDIR) $(COMMON_DEFINES)
+	CFLAGS	       += -D__LIBRETRO__ $(fpic) $(INCDIR) $(COMMON_DEFINES)
+else
+	CXXFLAGS       += -D__LIBRETRO__ -fpermissive $(fpic) $(INCDIR) $(COMMON_DEFINES)
+	CFLAGS	       += -D__LIBRETRO__ $(fpic) $(INCDIR) $(COMMON_DEFINES)
+endif
 
 all: $(TARGET)
 $(TARGET):
 	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
-	@echo "** $(RETRO_CROSSCOMPILING) **"
-	@echo "** $(RETRO_TARGET_HOST) **"
-	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
 ifeq ($(RETRO_CROSSCOMPILING), 1)
 	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
 	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-	RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
+	RETRO_CFLAGS="$(CFLAGS)$(DEPCFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)$(DEPCXXFLAGS)" \
 	RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
 	./2_build_cross_toolchain.sh
 else
 	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
 	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-	RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
+	RETRO_CFLAGS="$(CFLAGS)$(DEPCFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)$(DEPCXXFLAGS)" \
 	RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
 endif
 	cd $(CORE_DIR)/builds/libretro;\
@@ -220,7 +238,7 @@ endif
 		-DBUILD_SHARED_LIBS=ON -DCMAKE_PREFIX_PATH=$(CORE_DIR)/builds/libretro/deps/libretro \
 		-DPLAYER_ENABLE_TESTS=OFF -DPLAYER_WITH_XMP=OFF \
 		-DCMAKE_IGNORE_PATH="/lib;/usr/lib;/lib64;/usr/lib64"
-	cmake --build . -- -j4
+	cmake --build . -- -j$(COMPILER_CORE_COUNT)
 
 ifeq ($(platform), android)
 	mv $(TARGET_NAME)_libretro.so $(TARGET_NAME)_libretro_android.so

--- a/builds/libretro/Makefile.libretro
+++ b/builds/libretro/Makefile.libretro
@@ -221,16 +221,31 @@ all: $(TARGET)
 $(TARGET):
 	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
 ifeq ($(RETRO_CROSSCOMPILING), 1)
-	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
-	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-	RETRO_CFLAGS="$(CFLAGS)$(DEPCFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)$(DEPCXXFLAGS)" \
-	RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
-	./2_build_cross_toolchain.sh
+	ifneq ($(RETRO_DEPFLAGS), 0)
+		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+		RETRO_CFLAGS="$(DEPCFLAGS)" RETRO_CXXFLAGS="$(DEPCXXFLAGS)" \
+		RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
+		./2_build_cross_toolchain.sh
+	else
+		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+		RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
+		RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
+		./2_build_cross_toolchain.sh
+	endif
 else
-	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
-	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-	RETRO_CFLAGS="$(CFLAGS)$(DEPCFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)$(DEPCXXFLAGS)" \
-	RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
+	ifneq ($(RETRO_DEPFLAGS), 0)
+		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+		RETRO_CFLAGS="$(DEPCFLAGS)" RETRO_CXXFLAGS="$(DEPCXXFLAGS)" \
+		RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
+	else
+		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+		RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
+		RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
+	endif
 endif
 	cd $(CORE_DIR)/builds/libretro;\
 	CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" \

--- a/builds/libretro/Makefile.libretro
+++ b/builds/libretro/Makefile.libretro
@@ -128,7 +128,7 @@ else ifeq ($(platform), classic_armv7_a7)
 	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
 	-fmerge-all-constants -fno-math-errno \
 	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-	RETRO_DEPFLAGS += -Ofast \
+	RETRO_DEPFLAGS = -Ofast \
 	-fno-stack-protector -fno-ident -fomit-frame-pointer \
 	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
 	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
@@ -209,7 +209,7 @@ OBJECTS		= $(SOURCES_CXX:.cpp=.o) $(SOURCES_C:.c=.o)
 # away from the Libretro target compiler flags.
 ifneq ($(RETRO_DEPFLAGS), 0)
 	DEPCXXFLAGS    += -D__LIBRETRO__ -fpermissive $(fpic) $(INCDIR) $(RETRO_DEPFLAGS)
-	DEPCFLAGS	   += -D__LIBRETRO__ $(fpic) $(INCDIR) $(RETRO_DEPFLAGS)
+	DEPCFLAGS      += -D__LIBRETRO__ $(fpic) $(INCDIR) $(RETRO_DEPFLAGS)
 	CXXFLAGS       += -D__LIBRETRO__ -fpermissive $(fpic) $(INCDIR) $(COMMON_DEFINES)
 	CFLAGS	       += -D__LIBRETRO__ $(fpic) $(INCDIR) $(COMMON_DEFINES)
 else
@@ -221,31 +221,31 @@ all: $(TARGET)
 $(TARGET):
 	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
 ifeq ($(RETRO_CROSSCOMPILING), 1)
-	ifneq ($(RETRO_DEPFLAGS), 0)
-		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
-		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-		RETRO_CFLAGS="$(DEPCFLAGS)" RETRO_CXXFLAGS="$(DEPCXXFLAGS)" \
-		RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
-		./2_build_cross_toolchain.sh
-	else
-		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
-		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-		RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
-		RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
-		./2_build_cross_toolchain.sh
-	endif
+ifneq ($(RETRO_DEPFLAGS), 0)
+	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+	RETRO_CFLAGS="$(DEPCFLAGS)" RETRO_CXXFLAGS="$(DEPCXXFLAGS)" \
+	RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
+	./2_build_cross_toolchain.sh
 else
-	ifneq ($(RETRO_DEPFLAGS), 0)
-		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
-		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-		RETRO_CFLAGS="$(DEPCFLAGS)" RETRO_CXXFLAGS="$(DEPCXXFLAGS)" \
-		RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
-	else
-		cd $(CORE_DIR)/builds/libretro/deps/libretro; \
-		RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
-		RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
-		RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
-	endif
+	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+	RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
+	RETRO_LDFLAGS="$(LDFLAGS)" RETRO_TARGET_HOST="$(RETRO_TARGET_HOST)" \
+	./2_build_cross_toolchain.sh
+endif
+else
+ifneq ($(RETRO_DEPFLAGS), 0)
+	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+	RETRO_CFLAGS="$(DEPCFLAGS)" RETRO_CXXFLAGS="$(DEPCXXFLAGS)" \
+	RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
+else
+	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
+	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \
+	RETRO_CFLAGS="$(CFLAGS)" RETRO_CXXFLAGS="$(CXXFLAGS)" \
+	RETRO_LDFLAGS="$(LDFLAGS)" ./2_build_toolchain.sh
+endif
 endif
 	cd $(CORE_DIR)/builds/libretro;\
 	CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CXXFLAGS="$(CXXFLAGS)" LDFLAGS="$(LDFLAGS)" \

--- a/builds/libretro/Makefile.libretro
+++ b/builds/libretro/Makefile.libretro
@@ -104,6 +104,43 @@ else ifeq ($(platform), android)
 
 	RETRO_CROSSCOMPILING = 1
 	RETRO_TARGET_HOST = arm-linux-androideabi
+	
+	
+# Classic Platforms ####################
+# Platform affix = classic_<ISA>_<µARCH>
+# Help at https://modmyclassic.com/comp
+
+# (armv7 a7, hard point, neon based) ### 
+# NESC, SNESC, C64 mini 
+else ifeq ($(platform), classic_armv7_a7)
+	TARGET := $(TARGET_NAME)_libretro.so
+	fpic := -fPIC
+	COMMON_DEFINES += -Ofast \
+	-flto=4 -fwhole-program -fuse-linker-plugin \
+	-fdata-sections -ffunction-sections -Wl,--gc-sections \
+	-fno-stack-protector -fno-ident -fomit-frame-pointer \
+	-falign-functions=1 -falign-jumps=1 -falign-loops=1 \
+	-fno-unwind-tables -fno-asynchronous-unwind-tables -fno-unroll-loops \
+	-fmerge-all-constants -fno-math-errno \
+	-marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	LDFLAGS += -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
+	HAVE_NEON = 1
+	ARCH = arm
+	LIBS += -lpthread
+	COMMON_DEFINES += -DUSE_POSIX_MEMALIGN -D__RETRO_ARM__ -DARM
+	RETRO_CROSSCOMPILING = 1
+	RETRO_TARGET_HOST = arm-linux-gnueabihf
+	ifeq ($(shell echo `$(CC) -dumpversion` "< 4.9" | bc -l), 1)
+	  COMMON_DEFINES += -march=armv7-a
+	else
+	  COMMON_DEFINES += -march=armv7ve
+	  # If gcc is 5.0 or later
+	  ifeq ($(shell echo `$(CC) -dumpversion` ">= 5" | bc -l), 1)
+	    LDFLAGS += -static-libgcc -static-libstdc++
+	  endif
+	endif
+#######################################
+
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
 	CXXFLAGS += -DUSE_POSIX_MEMALIGN -D__RETRO_ARM__
@@ -161,6 +198,10 @@ CFLAGS	       += -D__LIBRETRO__ $(fpic) $(INCDIR) $(COMMON_DEFINES)
 
 all: $(TARGET)
 $(TARGET):
+	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
+	@echo "** $(RETRO_CROSSCOMPILING) **"
+	@echo "** $(RETRO_TARGET_HOST) **"
+	@echo "** BUILDING $(TARGET) FOR PLATFORM $(platform) **"
 ifeq ($(RETRO_CROSSCOMPILING), 1)
 	cd $(CORE_DIR)/builds/libretro/deps/libretro; \
 	RETRO_CC="$(CC)" RETRO_CXX="$(CXX)" \


### PR DESCRIPTION
- Added A7A7 platform for classics
- Added COMPILER_CORE_COUNT so users can select how many cores to build against when building the core. (Default is 4)
- Added RETRO_DEPFLAGS, this allows users to set compiler flags for the dependencies indepent of the target core build. This is extremely important when wanting to retain optimisations like LTO for the core but not on the dependencies (which would often break the dependency build)

Compile test fine - UAT testing underway. Considered WIP