### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,7 +71,9 @@ stages:
   variables:
     DEPS: builds/libretro/buildscripts/$PLATFORM_TARGET
   cache:
-    key: "easyrpg-deps-$PLATFORM_TARGET"
+    # PLATFORM_TARGET alone is not unique: linux-static is used by both the x64
+    # and the aarch64 deps job, which would share one cache entry
+    key: "easyrpg-deps-$CI_JOB_NAME"
     paths:
       - builds/libretro/buildscripts/$PLATFORM_TARGET/bin
       - builds/libretro/buildscripts/$PLATFORM_TARGET/include
@@ -203,10 +205,6 @@ deps:linux-aarch64:
     - .build-deps-easyrpg
   variables:
     PLATFORM_TARGET: linux-static
-  # linux-static is also used by the x64 deps job, so the inherited cache key
-  # would be shared between two architectures
-  cache:
-    key: "easyrpg-deps-$PLATFORM_TARGET-aarch64"
 
 libretro-build-linux-aarch64:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,8 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
   - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+  - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-x86.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-arm64.yml'
@@ -194,6 +196,35 @@ test:linux-x64:
   script:
     - !reference [.common, cmake]
     - !reference [.common, check]
+
+deps:linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64
+    - .build-deps-easyrpg
+  variables:
+    PLATFORM_TARGET: linux-static
+  # linux-static is also used by the x64 deps job, so the inherited cache key
+  # would be shared between two architectures
+  cache:
+    key: "easyrpg-deps-$PLATFORM_TARGET-aarch64"
+
+libretro-build-linux-aarch64:
+  extends:
+    - .core-defs
+    - .libretro-linux-aarch64-make-default
+  dependencies:
+    - deps:linux-aarch64
+  needs:
+    - deps:linux-aarch64
+  cache:
+    key: "$CI_COMMIT_REF_SLUG-linux-aarch64"
+    paths:
+      - build/
+  variables:
+    CMAKE_PRESET: linux-libretro-release
+  script:
+    - !reference [.common, cmake]
+    - !reference [.common, build]
 
 # macOS build
 deps:osx:


### PR DESCRIPTION
easyrpg is one of the cores missing from https://buildbot.libretro.com/nightly/linux/aarch64/latest/ , because the pipeline has no `linux-aarch64` job. This adds one, mirroring the x64 pair:

- `deps:linux-aarch64` — extends `.libretro-linux-aarch64` + `.build-deps-easyrpg` with `PLATFORM_TARGET: linux-static`, like `deps:linux-x64`.
- `libretro-build-linux-aarch64` — extends `.core-defs` + `.libretro-linux-aarch64-make-default`, same `linux-libretro-release` preset and the shared `.common` cmake/build scripts.

One thing that is not a plain copy: `.build-deps-easyrpg` derives its cache key from `PLATFORM_TARGET`, and aarch64 uses the same `linux-static` target as x64, so both jobs would share the `easyrpg-deps-linux-static` cache and could restore libraries built for the other architecture. The aarch64 deps job therefore overrides the key with an `-aarch64` suffix. Happy to solve that differently (e.g. adding `$CI_JOB_NAME` to the key in `.build-deps-easyrpg`) if you prefer it centralised.

No source or CMake changes were needed.

### Tested natively on aarch64

postmarketOS aarch64 (Snapdragon 670 / Adreno 618), running the same commands as the CI jobs:

- the `linux-static` dependency set (zlib, libpng, freetype, harfbuzz, pixman, expat, ogg/vorbis, mpg123, libsndfile, libxmp, speexdsp, wildmidi, opus(file), fluidsynth, nlohmann-json, inih, lhasa, fmt, ICU, liblcf, SDL2, FreeImage) builds clean with `0_build_everything.sh`;
- `cmake --preset linux-libretro-release … && cmake --build --preset linux-libretro-release` produces `easyrpg_libretro.so` as an aarch64 shared object with no errors;
- in RetroArch 1.22.2 the core loads [EasyRPG TestGame](https://github.com/EasyRPG/TestGame) (`TestGame-2000/RPG_RT.ldb`) and plays it — 900 frames, world map and party render correctly at ~75 FPS, clean exit.

Two notes from that run that are **not** aarch64 specific and do not affect the CI image (Ubuntu, GCC 12):

- with GCC 15, `libsndfile-1.2.2` in the deps set fails to compile (`src/ALAC/alac_decoder.c`: `enum { false = 0, true = 1 } bool;` is rejected under the new default `-std=c23`). Building the deps with `-std=gnu17` for C works around it locally.
- `fluidsynth` logs a missing `share/soundfonts/default.sf2` at startup; harmless, MIDI just needs a soundfont supplied by the user.