### PR TITLE
ci: fix the Android dependency build, add a 32-bit Linux one

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,8 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
   - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-i686.yml'
+  - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-aarch64.yml'
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-cmake-x86.yml'
@@ -198,6 +200,31 @@ test:linux-x64:
   script:
     - !reference [.common, cmake]
     - !reference [.common, check]
+
+deps:linux-i686:
+  extends:
+    - .libretro-linux-i686
+    - .build-deps-easyrpg
+  variables:
+    PLATFORM_TARGET: linux-static
+
+libretro-build-linux-i686:
+  extends:
+    - .core-defs
+    - .libretro-linux-i686-make-default
+  dependencies:
+    - deps:linux-i686
+  needs:
+    - deps:linux-i686
+  cache:
+    key: "$CI_COMMIT_REF_SLUG-linux-i686"
+    paths:
+      - build/
+  variables:
+    CMAKE_PRESET: linux-libretro-release
+  script:
+    - !reference [.common, cmake]
+    - !reference [.common, build]
 
 deps:linux-aarch64:
   extends:

--- a/builds/libretro/patches.sh
+++ b/builds/libretro/patches.sh
@@ -21,6 +21,11 @@ perl -pi -e 's/.\/4/#.\/4/' $BUILDSCRIPTS/android/0_build_everything.sh
 # project ("The API level 16 is not supported by the NDK").
 perl -pi -e 's/export TARGET_API=16/export TARGET_API=21/' $BUILDSCRIPTS/android/2_build_toolchain.sh
 
+# NDK 21 shipped a GNU assembler for the -no-integrated-as builds to call; the
+# current one does not, so clang falls back to the host /usr/bin/as, which
+# cannot assemble ARM ("unrecognized option '-EL'").
+perl -pi -e 's/-no-integrated-as //' $BUILDSCRIPTS/android/2_build_toolchain.sh
+
 ## Vita
 
 # Do not download the VitaSDK

--- a/builds/libretro/patches.sh
+++ b/builds/libretro/patches.sh
@@ -16,6 +16,11 @@ perl -pi -e 's/export ANDROID_NDK=.*/export ANDROID_NDK=\$NDK_ROOT/' $BUILDSCRIP
 # Do not build the Player APK
 perl -pi -e 's/.\/4/#.\/4/' $BUILDSCRIPTS/android/0_build_everything.sh
 
+# The NDK only supports API level 21 and up; the pinned buildscripts still ask
+# for 16 on armeabi-v7a, which stops the toolchain build at the first CMake
+# project ("The API level 16 is not supported by the NDK").
+perl -pi -e 's/export TARGET_API=16/export TARGET_API=21/' $BUILDSCRIPTS/android/2_build_toolchain.sh
+
 ## Vita
 
 # Do not download the VitaSDK


### PR DESCRIPTION
No pipeline has completed here in months, and it is all one job: `deps:android` dies, and because it sits in `build-deps-easyrpg`, everything behind it is skipped — the four Android jobs, and both Windows jobs too, since those have no `needs:` of their own and follow stage order. That is why the buildbot has no Android and no Windows core for easyrpg.

Two things stop it, both because the pinned `buildscripts` submodule was written for NDK 21 while the image now ships a current one:

1. `TARGET_API=16` for armeabi-v7a → `Android: The API level 16 is not supported by the NDK. Choose one in the range of [21, 35].`
2. `-no-integrated-as`. NDK 21 shipped a GNU assembler for clang to hand off to; the current NDK does not, so clang calls the host `/usr/bin/as`, which cannot assemble ARM: `unrecognized option '-EL'`.

Both are patched in `builds/libretro/patches.sh`, next to the Android patches already there, rather than by moving the submodule. Upstream fixed the same two things (API 21, flag removed) but those commits sit behind a year of dependency churn — SDL3, NDK 28, fluidsynth 2.5 — that every other platform building from these scripts would take on at the same time.

Verified by running `patches.sh` and `0_build_everything.sh` against a current NDK: the dependency build completes and lays down all four toolchains (armeabi-v7a, arm64-v8a, x86, x86_64) with icu, freetype, harfbuzz, fluidsynth, WildMidi, expat, fmt and the rest.

**Also adds `linux-i686`**, the same deps + build pair the other two Linux targets already have — same `linux-static` dependency target, same `linux-libretro-release` preset. Verified end to end in a 32-bit container: the dependencies build, and the core comes out as `easyrpg_libretro.so`, `ELF 32-bit LSB shared object, Intel 80386`.

webOS I looked at and left alone: `EasyRPG/buildscripts` has targets for 3ds, android, emscripten, ios, linux-static, macos, switch, tvos, vita, wii, wiiu and windows, but none for webOS, so it would need a dependency target written upstream first — that is a port, not a CI entry.