### PR TITLE
android: ask for API 21 on the 32-bit ABIs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -850,7 +850,7 @@
 			"name": "android-armeabi-v7a-parent",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "armeabi-v7a",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"hidden": true
@@ -970,7 +970,7 @@
 			"name": "android-x86-parent",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "x86",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"hidden": true

--- a/builds/cmake/CMakePresets.json.template
+++ b/builds/cmake/CMakePresets.json.template
@@ -85,7 +85,7 @@
 			"displayName": "Android armeabi-v7a",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "armeabi-v7a",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"easyrpg_platforms": ["libretro"]
@@ -105,7 +105,7 @@
 			"displayName": "Android x86",
 			"cacheVariables": {
 				"CMAKE_ANDROID_ARCH_ABI": "x86",
-				"CMAKE_ANDROID_API": "16"
+				"CMAKE_ANDROID_API": "21"
 			},
 			"inherits": "android-user",
 			"easyrpg_platforms": ["libretro"]


### PR DESCRIPTION
`android-armeabi-v7a` and `android-x86` fail at configure on the buildbot, in about 40 seconds:

```
CMake Error at .../Modules/Platform/Android-Determine.cmake:503 (message):
  Android: The API level 16 is not supported by the NDK.
  Choose one in the range of [21, 35].
```

Their presets are the only two still asking for API 16. `arm64-v8a` and `x86_64` say 21 — those ABIs never had anything lower, which is why only the 32-bit jobs break — and `builds/libretro/patches.sh` already rewrites the dependency toolchain's `TARGET_API=16` to 21, so the libretro deps are built against 21 either way.

The change is in `builds/cmake/CMakePresets.json.template`; `CMakePresets.json` is regenerated with `gen-cmake-presets.py`. Both android presets are `"easyrpg_platforms": ["libretro"]`, so nothing outside the libretro build sees it.
